### PR TITLE
Allow theme.class to accept an array of class names

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,11 +39,20 @@ Default styles, which you can override or replace with your own:
 
 ### themeSelector.themes
 
-- Type: `Array<{ name: String, class: String }>`
+- Type: `Array<{ name: String, class: String | Array<String> }>`
 - Default: `undefined`
 
 **Required.** An array of themes with a `name` for the select menu and a `class`
-which will be added to the document's `<body>` tag upon activation.
+which will be added to the document's `<body>` tag upon activation. The `class`
+value may be a single class name or an array of class names, all of which will
+be toggled together.
+
+```js
+themes: [
+  { name: "Light Theme", class: "theme-light" },
+  { name: "Dark Theme", class: ["theme-dark", "high-contrast"] },
+],
+```
 
 ### themeSelector.pathRegex
 

--- a/src/lib/functions.js
+++ b/src/lib/functions.js
@@ -7,20 +7,33 @@
 
 const { themes, pathRegex } = window.$docsify.themeSelector || {};
 
+function getThemeClasses(theme) {
+  return Array.isArray(theme.class) ? theme.class : [theme.class];
+}
+
+function getThemeKey(theme) {
+  return getThemeClasses(theme).join(" ");
+}
+
 function setTheme(newTheme) {
   localStorage.setItem("theme", newTheme);
-  themes?.forEach((theme) =>
-    document.body.classList.toggle(theme.class, theme.class === newTheme)
-  );
+  themes?.forEach((theme) => {
+    const isActive = getThemeKey(theme) === newTheme;
+    getThemeClasses(theme).forEach((cls) =>
+      document.body.classList.toggle(cls, isActive)
+    );
+  });
 }
 
 function renderThemeSelect() {
   const themeSelect = document.createElement("select");
   themeSelect.id = "theme-switcher__select";
-  themes?.forEach(
-    (theme) =>
-      (themeSelect.innerHTML += `<option value=${theme.class}>${theme.name}</option`)
-  );
+  themes?.forEach((theme) => {
+    const option = document.createElement("option");
+    option.value = getThemeKey(theme);
+    option.textContent = theme.name;
+    themeSelect.append(option);
+  });
   themeSelect.value = getActiveTheme();
   themeSelect.onchange = () => {
     setTheme(themeSelect.value);
@@ -38,7 +51,11 @@ function showSelector(pathRegex) {
 }
 
 export function getActiveTheme() {
-  return localStorage.getItem("theme") || (themes && themes[0].class);
+  return localStorage.getItem("theme") || (themes && getThemeKey(themes[0]));
+}
+
+export function getActiveThemeClasses() {
+  return getActiveTheme().split(" ").filter(Boolean);
 }
 
 export function renderThemeSwitcher() {

--- a/src/theme-switcher.js
+++ b/src/theme-switcher.js
@@ -8,7 +8,7 @@
  */
 import "./theme-switcher.css";
 import {
-  getActiveTheme,
+  getActiveThemeClasses,
   renderThemeSwitcher,
   setVisibility,
 } from "./lib/functions.js";
@@ -18,7 +18,7 @@ function themeSwitcher(hook, vm) {
 
   hook.mounted(() => {
     if (vm.config.themeSelector && themes.length) {
-      document.body.classList.add(getActiveTheme());
+      document.body.classList.add(...getActiveThemeClasses());
 
       const themeSwitcher = renderThemeSwitcher();
       setVisibility(themeSwitcher);


### PR DESCRIPTION
## Summary
- `themeSelector.themes[].class` now accepts either a single class name (existing behavior) or an array of class names that get toggled together on `<body>`.
- Refactored option rendering to use `createElement` so multi-class values (which contain spaces) round-trip safely through the select.
- README updated to document the new option type with an example.

## Test plan
- [ ] Configure a theme with `class: "theme-light"` (string) and verify it still toggles correctly.
- [ ] Configure a theme with `class: ["theme-dark", "high-contrast"]` (array) and verify all classes are added/removed together on `<body>`.
- [ ] Switch between string-class and array-class themes and confirm the previous theme's classes are removed.
- [ ] Reload the page and confirm the active theme persists from `localStorage`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)