### PR TITLE
Fix shared classes being cleared when switching themes

### DIFF
--- a/src/lib/functions.js
+++ b/src/lib/functions.js
@@ -17,11 +17,13 @@ function getThemeKey(theme) {
 
 function setTheme(newTheme) {
   localStorage.setItem("theme", newTheme);
-  themes?.forEach((theme) => {
-    const isActive = getThemeKey(theme) === newTheme;
-    getThemeClasses(theme).forEach((cls) =>
-      document.body.classList.toggle(cls, isActive)
-    );
+  const activeTheme = themes?.find((theme) => getThemeKey(theme) === newTheme);
+  const activeClasses = new Set(
+    activeTheme ? getThemeClasses(activeTheme) : []
+  );
+  const allClasses = new Set(themes?.flatMap(getThemeClasses));
+  allClasses.forEach((cls) => {
+    document.body.classList.toggle(cls, activeClasses.has(cls));
   });
 }
 


### PR DESCRIPTION
## Summary
- `setTheme` previously iterated each theme and toggled all of its classes off whenever that theme wasn't the active one. When themes share classes (e.g. a combined `["theme-dark", "theme-carson"]` theme alongside individual `theme-dark` / `theme-carson` themes), an inactive theme's iteration would clear classes the now-active theme depends on — final state depended on array order.
- Reconciles against the union of all theme classes using the active theme's class set, so shared classes resolve correctly regardless of theme order.

## Test plan
- [ ] With themes `theme-a`, `theme-b`, and combined `["theme-a", "theme-b"]`, switch from the combined theme to `theme-a` and confirm only `theme-a` remains on `<body>`.
- [ ] Switch from `theme-a` to the combined theme and confirm both `theme-a` and `theme-b` are on `<body>`.
- [ ] Reload the page after each switch and confirm the active theme persists.

🤖 Generated with [Claude Code](https://claude.com/claude-code)